### PR TITLE
Add click handler to open configured repo

### DIFF
--- a/github_stars.py
+++ b/github_stars.py
@@ -4,8 +4,6 @@ import urllib.request
 
 import iterm2
 
-github_repo = None
-
 REPO_KNOB_NAME = 'GITHUB_REPO'
 TOKEN_KNOB_NAME = 'GITHUB_TOKEN'
 
@@ -19,6 +17,7 @@ def human_number(num):
 
 
 async def main(connection):
+    github_repo = None
     app = await iterm2.async_get_app(connection)
 
     component = iterm2.StatusBarComponent(
@@ -35,7 +34,6 @@ async def main(connection):
 
     @iterm2.RPC
     async def onclick(session_id):
-        global github_repo
         proc = await asyncio.create_subprocess_shell(
             f'open https://github.com/{github_repo}',
             stdout= asyncio.subprocess.PIPE,
@@ -45,7 +43,6 @@ async def main(connection):
 
     @iterm2.StatusBarRPC
     async def github_stars_coroutine(knobs):
-        global github_repo
         github_repo = knobs[REPO_KNOB_NAME]
         token = knobs[TOKEN_KNOB_NAME]
         info_url = f'https://api.github.com/repos/{github_repo}'


### PR DESCRIPTION
Here you go, fixes #5. I've never written python before so maybe some of this isn't good practice, but hey it works. Also, in the future, it would be cool to display the stars if the working directory is a github repo. 